### PR TITLE
Permissions and move to Traefik

### DIFF
--- a/app/demoservice/forms.py
+++ b/app/demoservice/forms.py
@@ -27,6 +27,7 @@ class DemoStartForm(forms.Form):
             github_repo=self.cleaned_data['github_repo'],
             github_pr=self.cleaned_data['github_pr'],
             send_github_notification=self.cleaned_data['github_notify'],
+            github_verify_sender=False,
         )
         return True
 

--- a/app/demoservice/libs/demos.py
+++ b/app/demoservice/libs/demos.py
@@ -228,9 +228,14 @@ def start_demo(
     demo_url_full = ''.join(['http://', demo_url, '/', demo_url_path, '/'])
     logger.info('Starting demo: %s', demo_url_full)
 
+    port = _get_open_port()
+
     docker_options = ''
     docker_labels = {
         'rap.host': demo_url,
+        'traefik.enable': True,
+        'traefik.frontend.rule': 'Host:{url}'.format(url=demo_url),
+        'traefik.port': port,
         'run.demo': True,
         'run.demo.url': demo_url,
         'run.demo.url_full': demo_url_full,
@@ -252,7 +257,6 @@ def start_demo(
 
     run_env = os.environ.copy()
     run_env["CANONICAL_WEBTEAM_RUN_SERVE_DOCKER_OPTS"] = docker_options
-    port = _get_open_port()
     serve_args = ''
     if 'tutorials' in github_repo:
         serve_args = './tutorials/*/'

--- a/app/demoservice/libs/demos.py
+++ b/app/demoservice/libs/demos.py
@@ -235,7 +235,7 @@ def start_demo(
     docker_options = ''
     docker_labels = {
         'rap.host': demo_url,
-        'traefik.enable': True,
+        'traefik.enable': 'true',
         'traefik.frontend.rule': 'Host:{url}'.format(url=demo_url),
         'traefik.port': port,
         'run.demo': True,

--- a/app/demoservice/libs/demos.py
+++ b/app/demoservice/libs/demos.py
@@ -225,7 +225,9 @@ def start_demo(
         logger.info('Setting demo path to %s', demo_url_path)
 
     # Start ./run server with extra options
-    demo_url_full = ''.join(['http://', demo_url, '/', demo_url_path, '/'])
+    demo_url_full = ''.join(['http://', demo_url, '/'])
+    if demo_url_path:
+        demo_url_full = ''.join([demo_url_full, demo_url_path, '/'])
     logger.info('Starting demo: %s', demo_url_full)
 
     port = _get_open_port()

--- a/app/demoservice/libs/demos.py
+++ b/app/demoservice/libs/demos.py
@@ -124,9 +124,16 @@ def start_demo(
         logger = logging.getLogger(__name__)
 
     if github_verify_sender:
+        logger.debug('Verifying if user is collaborator of repo',)
         if not github_sender:
             logger.error('GitHub webhook sender is not set for verification')
             return None
+        logger.debug(
+            'Verifying %s is a collaborator of %s/%s',
+            github_sender,
+            github_user,
+            github_repo,
+        )
         if not _is_repo_collaborator(github_user, github_repo, github_sender):
             logger.info(
                 "%s is not a collaborator of this repo", github_sender
@@ -135,6 +142,7 @@ def start_demo(
                 "User is not a collaborator of this repo. "
                 "Please start demo manually."
             )
+        logger.info('User is a collaborator of the repo')
 
     logger.info('Preparing demo: %s', demo_url)
 

--- a/app/demoservice/libs/demos.py
+++ b/app/demoservice/libs/demos.py
@@ -8,6 +8,7 @@ import shutil
 import socket
 import yaml
 from django.conf import settings
+from github3 import login
 from subprocess import Popen
 
 from demoservice.logging import get_demo_logger
@@ -24,6 +25,12 @@ def _get_open_port():
     port = s.getsockname()[1]
     s.close()
     return port
+
+
+def _is_repo_collaborator(repo_owner, repo_name, user):
+    gh = login('-', password=settings.GITHUB_TOKEN)
+    repo = gh.repository(repo_owner, repo_name)
+    return repo.is_collaborator(user)
 
 
 def get_demo_context(
@@ -107,12 +114,27 @@ def start_demo(
     github_user,
     github_repo,
     github_pr,
+    github_sender=None,
+    github_verify_sender=True,
     context=None,
 ):
     if context:
         logger = get_demo_logger(__name__, **context)
     else:
         logger = logging.getLogger(__name__)
+
+    if github_verify_sender:
+        if not github_sender:
+            logger.error('GitHub webhook sender is not set for verification')
+            return None
+        if not _is_repo_collaborator(github_user, github_repo, github_sender):
+            logger.info(
+                "%s is not a collaborator of this repo", github_sender
+            )
+            return (
+                "User is not a collaborator of this repo. "
+                "Please start demo manually."
+            )
 
     logger.info('Preparing demo: %s', demo_url)
 

--- a/app/demoservice/libs/github.py
+++ b/app/demoservice/libs/github.py
@@ -14,12 +14,15 @@ def handle_pull_Request(payload):
     pull_request_id = payload['number']
     repo_owner = payload['repository']['owner']['login']
     repo_name = payload['repository']['name']
+    sender = payload['sender']['login']
 
     if action == 'opened' or action == 'synchronize':
         queue_start_demo(
             github_user=repo_owner,
             github_repo=repo_name,
             github_pr=pull_request_id,
+            github_sender=sender,
+            github_verify_sender=True,
             send_github_notification=(action == 'opened'),
         )
 

--- a/app/demoservice/settings.py
+++ b/app/demoservice/settings.py
@@ -154,7 +154,6 @@ OPENID_LAUNCHPAD_TEAMS_MAPPING_AUTO = True
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
-
 # RabbitMQ
 RABBITMQ_HOST = os.environ.get('RABBITMQ_HOST', 'localhost')
 RABBITMQ_PORT = os.environ.get('RABBITMQ_PORT', 5672)
@@ -168,6 +167,7 @@ if DEBUG:
     # In debug, run synchronously
     CELERY_TASK_ALWAYS_EAGER = True
 
+GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN')
 
 DEMO_DIR = '/srv/run.demo.haus-demos/'
 if DEBUG:

--- a/app/demoservice/tasks.py
+++ b/app/demoservice/tasks.py
@@ -33,6 +33,8 @@ def start_demo_task(
     github_repo,
     github_pr,
     context,
+    github_sender=None,
+    github_verify_sender=True,
     **kwargs
 ):
     logger = get_demo_logger(__name__, **context)
@@ -44,6 +46,8 @@ def start_demo_task(
             github_user=github_user,
             github_repo=github_repo,
             github_pr=github_pr,
+            github_sender=github_sender,
+            github_verify_sender=github_verify_sender,
             context=context,
         )
     except Exception as e:
@@ -112,6 +116,8 @@ def queue_start_demo(
     github_user,
     github_repo,
     github_pr,
+    github_sender=None,
+    github_verify_sender=True,
     send_github_notification=False,
 ):
     demo_url = get_demo_url_pr(github_repo, github_pr)
@@ -131,7 +137,12 @@ def queue_start_demo(
     )
 
     tasks = [
-        start_demo_task.s(context=context, **context)
+        start_demo_task.s(
+            context=context,
+            github_sender=github_sender,
+            github_verify_sender=github_verify_sender,
+            **context,
+        )
     ]
     if send_github_notification:
         tasks.append(notify_github_task.s(context=context, **context))

--- a/app/demoservice/templates/demo_index.html
+++ b/app/demoservice/templates/demo_index.html
@@ -13,7 +13,7 @@
           <ul>
             {% for demo in demos %}
               <li>
-                <a href="http://{{ demo.url }}">{{ demo.url }}</a>
+                <a href="{{ demo.url_full }}">{{ demo.url }}</a>
               </li>
             {% endfor %}
           </ul>

--- a/app/demoservice/views.py
+++ b/app/demoservice/views.py
@@ -42,9 +42,12 @@ class DemoIndexView(TemplateView):
         demos = []
         for container in demo_containers:
             labels = container.labels
+            url = labels.get('run.demo.url', '')
+            url_full = labels.get('run.demo.url_full', url)
             demo = {
                 'name': container.name,
-                'url': labels.get('run.demo.url', ''),
+                'url': url,
+                'url_full': url_full,
                 'github_user': labels.get('run.demo.github_user', ''),
                 'github_repo': labels.get('run.demo.github_repo', ''),
                 'github_branch': labels.get('run.demo.github_branch', ''),

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Django==1.11.3
 django-openid-auth==0.14
 docker==2.4.2
 docker-pycreds==0.2.1
+github3.py==0.9.6
 gunicorn==19.7.1
 idna==2.5
 kombu==4.0.2
@@ -18,6 +19,8 @@ pytz==2017.2
 PyYAML==3.12
 requests==2.18.1
 six==1.10.0
+uritemplate==3.0.0
+uritemplate.py==3.0.2
 urllib3==1.21.1
 vine==1.1.3
 websocket-client==0.44.0


### PR DESCRIPTION
Theses changes do the following:

- Fix double slashes in URLs
- Correctly link dashboard items with paths
- Move domain routing to Traefik
- Add checks if user submitting PR is a collaborator on repo if it isn't started from the dashboard.

Traefik.io is much faster domain routing and stops one or two problems with a domain not being set.
It also gives a 404 when the domain doesn't exist rather than an error!
This, like the existing Rancher Active Proxy set up, uses labels on Docker containers to decide how to route. (Traefik can do a lot more but it works really well for this)