### PR TITLE
Filter out duplicate demos entries on index page

### DIFF
--- a/app/demoservice/views.py
+++ b/app/demoservice/views.py
@@ -50,7 +50,8 @@ class DemoIndexView(TemplateView):
                 'github_branch': labels.get('run.demo.github_branch', ''),
                 'github_pr': labels.get('run.demo.github_pr', ''),
             }
-            demos.append(demo)
+            if demo not in demos:
+                demos.append(demo)
         return demos
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Simple filtering of duplicated demos entries on index.

Issue illustrated here:
![screenshot from 2017-10-03 11-11-22](https://user-images.githubusercontent.com/18480003/31117848-a1c92878-a82b-11e7-8f33-1637bc42ad1d.png)
