### PR TITLE
Improve demo view

### DIFF
--- a/app/demoservice/templates/demo_index.html
+++ b/app/demoservice/templates/demo_index.html
@@ -8,15 +8,30 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-6">
+      <div class="col-12">
         {% if demos %}
-          <ul>
-            {% for demo in demos %}
-              <li>
-                <a href="{{ demo.url_full }}">{{ demo.url }}</a>
-              </li>
-            {% endfor %}
-          </ul>
+        <table class="p-table" role="grid">
+            <thead>
+              <tr role="row">
+                <th scope="col" role="columnheader" id="t-url" aria-sort="none">Name</th>
+                <th scope="col" role="columnheader" id="t-github" aria-sort="none">GitHub</th>
+              </tr>
+            </thead>
+            <tbody>
+              <ul>
+                {% for demo in demos %}
+                  <tr role="row">
+                    <td role="gridcell">
+                      <a href="{{ demo.url_full }}">{{ demo.url }}</a>
+                    </td>
+                    <td role="gridcell">
+                      <a href="{{ demo.github_url }}" class="p-link--external">GitHub</a>
+                    </td>
+                  </tr>
+                {% endfor %}
+              </ul>
+            </tbody>
+          </table>
         {% else %}
           No currently running demos found.
         {% endif %}

--- a/app/demoservice/views.py
+++ b/app/demoservice/views.py
@@ -4,6 +4,7 @@ import hmac
 import http
 import json
 import logging
+from operator import itemgetter
 from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponse, HttpResponseForbidden
@@ -55,6 +56,7 @@ class DemoIndexView(TemplateView):
             }
             if demo not in demos:
                 demos.append(demo)
+        demos.sort(key=itemgetter('url'))
         return demos
 
     def get_context_data(self, **kwargs):

--- a/app/demoservice/views.py
+++ b/app/demoservice/views.py
@@ -29,6 +29,23 @@ def demo_index(request):
     return HttpResponse(running_demos)
 
 
+def _get_github_url(demo):
+    url = ''
+    if demo['github_branch']:
+        url = 'https://github.com/{user}/{repo}/tree/{branch}'.format(
+            user=demo['github_user'],
+            repo=demo['github_repo'],
+            branch=demo['github_branch'],
+        )
+    if demo['github_pr']:
+        url = 'https://github.com/{user}/{repo}/pull/{id}'.format(
+            user=demo['github_user'],
+            repo=demo['github_repo'],
+            id=demo['github_pr'],
+        )
+    return url
+
+
 class DemoIndexView(TemplateView):
     template_name = 'demo_index.html'
 
@@ -54,6 +71,7 @@ class DemoIndexView(TemplateView):
                 'github_branch': labels.get('run.demo.github_branch', ''),
                 'github_pr': labels.get('run.demo.github_pr', ''),
             }
+            demo['github_url'] = _get_github_url(demo)
             if demo not in demos:
                 demos.append(demo)
         demos.sort(key=itemgetter('url'))


### PR DESCRIPTION
- Sort demo list (finally)
- Change view into a table and add a GitHub PR link to start with

## QA
To QA you will need to `pip install -r requirements` in the virtual python environment of your choice
Start with `DJANGO_DEBUG=True python3 ./app/manage.py runserver`

I was starting fake demos on my computer with:
``` bash
docker run --rm --detach -l run.demo.url_full=http://www.ubuntu.com-pr-2257.run.demo.haus/ -l run.demo.github_pr=2257 -l run.demo.url=www.ubuntu.com-pr-2257.run.demo.haus -l run.demo.github_user=canonical-websites -l run.demo.github_repo=www.ubuntu.com -l run.demo=True ipfaffy/docker-test-http-server

```

## Screenshots
![selection_007](https://user-images.githubusercontent.com/322693/31270237-69611c96-aa7b-11e7-9851-aae26ccba9bc.png)
