### PR TITLE
Upgrade vanilla and use notifications pattern

### DIFF
--- a/app/demoservice/templates/base.html
+++ b/app/demoservice/templates/base.html
@@ -33,7 +33,13 @@
       <div class="row">
         <div class="col-12">
           {% for message in messages %}
-            <div class="p-notification">
+            {% if message.tags == "success" %}
+              <div class="p-notification--positive">
+            {% elif message.tags == "error" %}
+              <div class="p-notification--negative">
+            {% else %}
+              <div class="p-notification">
+            {% endif %}
               <p class="p-notification__response {% if message.tags %}{{ message.tags }}{% endif %}">
                 {{ message }}
               </p>

--- a/app/demoservice/templates/base.html
+++ b/app/demoservice/templates/base.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title>./run demos</title>

--- a/app/demoservice/templates/base.html
+++ b/app/demoservice/templates/base.html
@@ -29,19 +29,19 @@
   </div>
 </header>
   {% if messages %}
-    {% for message in messages %}
     <div class="p-strip">
       <div class="row">
         <div class="col-12">
-          <div class="p-notification">
-            <p class="p-notification__response {% if message.tags %}{{ message.tags }}{% endif %}">
-              {{ message }}
-            </p>
-          </div>
+          {% for message in messages %}
+            <div class="p-notification">
+              <p class="p-notification__response {% if message.tags %}{{ message.tags }}{% endif %}">
+                {{ message }}
+              </p>
+            </div>
+          {% endfor %}
         </div>
       </div>
     </div>
-    {% endfor %}
   {% endif %}
   {% block content %}
   {% endblock %}

--- a/app/demoservice/templates/base.html
+++ b/app/demoservice/templates/base.html
@@ -29,7 +29,7 @@
   </div>
 </header>
   {% if messages %}
-    <div class="p-strip">
+    <div class="p-strip is-shallow">
       <div class="row">
         <div class="col-12">
           {% for message in messages %}

--- a/app/demoservice/templates/base.html
+++ b/app/demoservice/templates/base.html
@@ -28,13 +28,21 @@
     </nav>
   </div>
 </header>
-{% if messages %}
-  <ul class="messages">
+  {% if messages %}
     {% for message in messages %}
-      <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+    <div class="p-strip">
+      <div class="row">
+        <div class="col-12">
+          <div class="p-notification">
+            <p class="p-notification__response {% if message.tags %}{{ message.tags }}{% endif %}">
+              {{ message }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
     {% endfor %}
-  </ul>
-{% endif %}
+  {% endif %}
   {% block content %}
   {% endblock %}
 </body>


### PR DESCRIPTION
## Done

- Upgrade Vanilla to 1.6.1
- Use notifications pattern for flash messages

## Help needed

- The only regression I can see after upgrading is the mis-alignment of the checkbox on the "Start/Update" page..

<img width="645" alt="screen shot 2017-10-27 at 18 05 31" src="https://user-images.githubusercontent.com/505570/32116192-8b2c6e44-bb41-11e7-9c70-e0b7dac797aa.png">

As this markup seems to be generated, I'm struggling to figure out how to correct it?