### PR TITLE
Remove unused RAP label

### DIFF
--- a/app/demoservice/libs/demos.py
+++ b/app/demoservice/libs/demos.py
@@ -242,7 +242,6 @@ def start_demo(
 
     docker_options = ''
     docker_labels = {
-        'rap.host': demo_url,
         'traefik.enable': 'true',
         'traefik.frontend.rule': 'Host:{url}'.format(url=demo_url),
         'traefik.port': port,


### PR DESCRIPTION
Remove Rancher Active Proxy label that we apply to Docker.

We do not use RAP anymore. Originally this label was how we directed subdomains to the correct location. Now we use Traefik to direct subdomains (which uses the labels right below this deleted line).