### PR TITLE
Normalise demo names

### DIFF
--- a/app/demoservice/libs/demos.py
+++ b/app/demoservice/libs/demos.py
@@ -14,7 +14,7 @@ from subprocess import Popen
 from demoservice.logging import get_demo_logger
 
 
-DEMO_PR_URL_TEMPLATE = '{repo_name}-pr-{github_pr}.run.demo.haus'
+DEMO_PR_URL_TEMPLATE = '{repo_name}-{org_name}-pr-{github_pr}.run.demo.haus'
 GITHUB_CLONE_URL = 'https://github.com/{github_user}/{github_repo}.git'
 
 
@@ -47,11 +47,12 @@ def get_demo_context(
     }
 
 
-def get_demo_url_pr(repo_name, github_pr):
+def get_demo_url_pr(org_name, repo_name, github_pr):
     return DEMO_PR_URL_TEMPLATE.format(
+        org_name=org_name,
         repo_name=repo_name,
         github_pr=github_pr,
-    )
+    ).lower()
 
 
 def notify_github_pr(

--- a/app/demoservice/tasks.py
+++ b/app/demoservice/tasks.py
@@ -120,7 +120,7 @@ def queue_start_demo(
     github_verify_sender=True,
     send_github_notification=False,
 ):
-    demo_url = get_demo_url_pr(github_repo, github_pr)
+    demo_url = get_demo_url_pr(github_user, github_repo, github_pr)
     context = get_demo_context(
         demo_url=demo_url,
         github_user=github_user,
@@ -154,7 +154,7 @@ def queue_stop_demo(
     github_repo,
     github_pr,
 ):
-    demo_url = get_demo_url_pr(github_repo, github_pr)
+    demo_url = get_demo_url_pr(github_user, github_repo, github_pr)
     context = get_demo_context(
         demo_url=demo_url,
         github_user=github_user,


### PR DESCRIPTION
## Done
Add GitHub organization to each demo's name and lowercase it to avoid duplicated demos and to stop demos from repositories with the same but different organizations overriding each other.

## QA
- Run the demo server locally
- Go to the start demo page and start a new demo, using at least one upper case letter in each field.
- Verify the demo name is all lower-cased and begins with the repository's organization name.

## Issues
#16 

## Notes
It's probably better to perform a cleanup after releasing this, to make sure we are not left with any stale demos.