### PR TITLE
Add footer with link to GitHub

### DIFF
--- a/app/demoservice/templates/base.html
+++ b/app/demoservice/templates/base.html
@@ -51,5 +51,11 @@
   {% endif %}
   {% block content %}
   {% endblock %}
+  <footer class="p-footer">
+    <div class="row">
+        <p>© {% now "Y" %} Canonical Ltd.</p>
+        <a href="https://github.com/canonical-webteam/demoservice">Source code on GitHub</a>
+    </div>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Done

Add a link to GitHub in the dashboard.

## QA

- Start the demoservice locally.
- Verify there is a footer in the dashboard with a link to the github repo.

## Issues

#25