### PR TITLE
Update Django to 1.11.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ celery==4.0.2
 certifi==2017.4.17
 chardet==3.0.4
 defusedxml==0.5.0
-Django==1.11.3
+Django==1.11.15
 django-openid-auth==0.14
 docker==2.4.2
 docker-pycreds==0.2.1


### PR DESCRIPTION
## Done

Upgrade django version to 1.11.15, to avoid security vulnerabilities.

## QA

- Create a virtual and install requirements
- Run `DJANGO_DEBUG=True python3 app/manage.py runserver`
- Browse the app and verify it's still working.

## Issues
FIxes #41 