### PR TITLE
Add links to start and stop forms in index page

### DIFF
--- a/app/demoservice/templates/demo_index.html
+++ b/app/demoservice/templates/demo_index.html
@@ -15,6 +15,7 @@
               <tr role="row">
                 <th scope="col" role="columnheader" id="t-url" aria-sort="none">Name</th>
                 <th scope="col" role="columnheader" id="t-github" aria-sort="none">GitHub</th>
+                <th scope="col" role="columnheader" id="t-github" aria-sort="none">Options</th>
               </tr>
             </thead>
             <tbody>
@@ -26,6 +27,11 @@
                     </td>
                     <td role="gridcell">
                       <a href="{{ demo.github_url }}" class="p-link--external">GitHub</a>
+                    </td>
+                    <td role="gridcell">
+                      <a href="{% url 'demo_start'%}?url={{ demo.github_url }}">Update</a>
+                      <span> | </span>
+                      <a href="{% url 'demo_stop' %}?url={{ demo.github_url }}">Stop</a>
                     </td>
                   </tr>
                 {% endfor %}


### PR DESCRIPTION
## Done
Added a links to pre-filled demo start/stop forms to the demo list page.

## QA
- Create a virtual environment and install requirements
- Run `DJANGO_DEBUG=true python3 app/manage.py runserver`
- Go to the demo list page and verify the `Update` and `Stop` links take you to pre-filled start and stop form pages respectively.

## Issues
Fixes #37