### PR TITLE
Add initial support for launchpad webhooks

### DIFF
--- a/app/demoservice/settings.py
+++ b/app/demoservice/settings.py
@@ -174,6 +174,7 @@ if DEBUG:
     DEMO_DIR = os.path.join(BASE_DIR, 'demos')
 
 GITHUB_WEBHOOK_SECRET = os.environ.get('GITHUB_WEBHOOK_SECRET')
+LAUNCHPAD_WEBHOOK_SECRET = os.environ.get('LAUNCHPAD_WEBHOOK_SECRET')
 
 default_log_level = 'DEBUG' if DEBUG else 'WARNING'
 log_level = os.environ.get('LOG_LEVEL', default_log_level)

--- a/app/demoservice/urls.py
+++ b/app/demoservice/urls.py
@@ -24,6 +24,7 @@ from demoservice.views import (
     DemoStartView,
     DemoStopView,
     github_webhook,
+    launchpad_webhook
 )
 
 
@@ -37,6 +38,7 @@ def _login_required(function, *args, **kwargs):
 urlpatterns = [
     url(r'^openid/', include('django_openid_auth.urls')),
     url(r'^webhook/github$', github_webhook),
+    url(r'^webhook/launchpad$', launchpad_webhook),
     url(
         r'^start$',
         _login_required(DemoStartView.as_view()),


### PR DESCRIPTION
# DONE
Add new endpoint for launchpad webhooks. It's initially just logging the payload sent by launchpad.

# QA

# ISSUES

Fixes #221