### PR TITLE
Add launchpad tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Running the service with `DJANGO_DEBUG=True` will run the database as sqlite and
 
 The official Python documentation has a page on [virtual environments](https://docs.python.org/3/tutorial/venv.html). Another great option is [pyenv](https://github.com/pyenv/pyenv) with [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv).
 
-### (Optional) Running fake demos
+### Running fake demos
 
 The UI isn't useful without running demos. If you want to run a demo, there is a helper script for a lightweight demo:
 
@@ -53,4 +53,15 @@ They will run in the background. Delete all the demos with:
 
 ``` bash
 ./bin/delete_fake_demos
+```
+
+### Sending fake webhooks in development
+
+If you need to test the webhook views or simply need to fake a webhook, you can use the scripts provided in bin/. 
+You will find sample payloads to use with the scripts in bin/data. Webhook signature validation should be disabled in DEBUG mode.
+It's highly likely that you will need to customize this sample payloads to use them.
+
+``` bash
+./bin/send_fake_github_webhook bin/data/github.json
+./bin/send_fake_launchpad_webhook bin/data/launchpad.json
 ```

--- a/app/demoservice/forms.py
+++ b/app/demoservice/forms.py
@@ -4,7 +4,7 @@ from demoservice.libs.github import (
     is_valid_github_url,
     get_github_info_from_url,
 )
-from demoservice.tasks import queue_start_demo, queue_stop_demo
+from demoservice.tasks.github import queue_start_demo, queue_stop_demo
 
 
 class DemoFormMixin(forms.Form):

--- a/app/demoservice/libs/github.py
+++ b/app/demoservice/libs/github.py
@@ -1,5 +1,5 @@
 import re
-from demoservice.tasks import queue_start_demo, queue_stop_demo
+from demoservice.tasks.github import queue_start_demo, queue_stop_demo
 
 
 GITHUB_PR_URL_REGEX = re.compile(

--- a/app/demoservice/libs/launchpad.py
+++ b/app/demoservice/libs/launchpad.py
@@ -1,0 +1,44 @@
+from demoservice.tasks.launchpad import (
+    queue_start_launchpad_demo,
+    queue_stop_launchpad_demo,
+)
+
+DEMO_PR_URL_TEMPLATE = '{repo_name}-{org_name}-pr-{pr}.run.demo.haus'
+
+
+def get_demo_url(repo, pr):
+    return "{repo}-launchpad-pr-{pr}.run.demo.haus".format(
+        repo=repo,
+        pr=pr
+    )
+
+
+def get_context_from_payload(payload):
+    pr = payload["merge_proposal"].split("/")[-1]
+    user = payload["new"]["source_git_repository"].split("/")[1]
+    repo = payload["new"]["target_git_repository"].split("/")[2]
+    branch = payload["new"]["source_git_path"].split("/")[-1]
+
+    return dict(
+        demo_url=get_demo_url(repo, pr),
+        user=user,
+        repo=repo,
+        branch=branch,
+        pr=pr
+    )
+
+
+def handle_webhook(event, payload):
+    if event == "merge-proposal:0.1":
+        handle_merge_proposal(payload)
+
+
+def handle_merge_proposal(payload):
+    action = payload["action"]
+    context = get_context_from_payload(payload)
+
+    if action == "created" or action == "modified":
+        queue_start_launchpad_demo(context=context, **context)
+
+    if action == "closed":
+        queue_stop_launchpad_demo(context=context, **context)

--- a/app/demoservice/settings.py
+++ b/app/demoservice/settings.py
@@ -176,7 +176,7 @@ GITHUB_WEBHOOK_SECRET = os.environ.get('GITHUB_WEBHOOK_SECRET')
 LAUNCHPAD_WEBHOOK_SECRET = os.environ.get('LAUNCHPAD_WEBHOOK_SECRET')
 
 DOCKERFILE_REPO_TEMPLATE = (
-    "https://raw.githubusercontent.com/jpmartinspt/dockerfiles/master/"
+    "https://raw.githubusercontent.com/canonical-webteam/dockerfiles/master/"
     "{}/{}/{}"
 )
 

--- a/app/demoservice/settings.py
+++ b/app/demoservice/settings.py
@@ -175,6 +175,11 @@ if DEBUG:
 GITHUB_WEBHOOK_SECRET = os.environ.get('GITHUB_WEBHOOK_SECRET')
 LAUNCHPAD_WEBHOOK_SECRET = os.environ.get('LAUNCHPAD_WEBHOOK_SECRET')
 
+DOCKERFILE_REPO_TEMPLATE = (
+    "https://raw.githubusercontent.com/jpmartinspt/dockerfiles/master/"
+    "{}/{}/{}"
+)
+
 default_log_level = 'DEBUG' if DEBUG else 'WARNING'
 log_level = os.environ.get('LOG_LEVEL', default_log_level)
 LOGGING = {

--- a/app/demoservice/tasks/__init__.py
+++ b/app/demoservice/tasks/__init__.py
@@ -1,0 +1,17 @@
+import os
+from celery import Celery
+
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'demoservice.settings')
+
+app = Celery('demoservice')
+
+# Using a string here means the worker don't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()

--- a/app/demoservice/tasks/github.py
+++ b/app/demoservice/tasks/github.py
@@ -1,6 +1,4 @@
-import os
-from celery import Celery, chain
-
+from celery import chain
 from demoservice.libs.demos import (
     get_demo_context,
     get_demo_url_pr,
@@ -9,20 +7,7 @@ from demoservice.libs.demos import (
     stop_demo,
 )
 from demoservice.logging import get_demo_logger
-
-# set the default Django settings module for the 'celery' program.
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'demoservice.settings')
-
-app = Celery('demoservice')
-
-# Using a string here means the worker don't have to serialize
-# the configuration object to child processes.
-# - namespace='CELERY' means all celery-related configuration keys
-#   should have a `CELERY_` prefix.
-app.config_from_object('django.conf:settings', namespace='CELERY')
-
-# Load task modules from all registered Django app configs.
-app.autodiscover_tasks()
+from demoservice.tasks import app
 
 
 @app.task(bind=True, max_retries=2)

--- a/app/demoservice/tasks/launchpad.py
+++ b/app/demoservice/tasks/launchpad.py
@@ -1,0 +1,105 @@
+import logging
+from demoservice.libs.demos import (
+    start_launchpad_demo,
+    stop_launchpad_demo
+)
+from demoservice.tasks import app
+
+
+@app.task(bind=True, max_retries=2)
+def start_launchpad_demo_task(
+    self,
+    demo_url,
+    user,
+    repo,
+    branch,
+    pr,
+    context,
+    **kwargs
+):
+    logger = logging.getLogger(__name__)
+    logger.info("Starting start_launchpad_demo_task task for %s", demo_url)
+    try:
+        return start_launchpad_demo(
+            demo_url=demo_url,
+            user=user,
+            repo=repo,
+            branch=branch,
+            pr=pr,
+            context=context
+        )
+    except Exception as e:
+        logger.error(e)
+        # Retry on failure with a growing cooldown
+        retry_count = self.request.retries
+        seconds_to_wait = 2 * retry_count
+        raise self.retry(exc=e, countdown=seconds_to_wait)
+
+
+@app.task(bind=True, max_retries=2)
+def stop_launchpad_demo_task(
+    self,
+    demo_url,
+    context,
+    **kwargs
+):
+    logger = logging.getLogger(__name__)
+    logger.info("Starting stop_launchpad_demo_task task for %s", demo_url)
+
+    try:
+        return stop_launchpad_demo(
+            demo_url=demo_url,
+            context=context
+        )
+    except Exception as e:
+        logger.error(e)
+        # Retry on failure with a growing cooldown
+        retry_count = self.request.retries
+        seconds_to_wait = 2 * retry_count
+        raise self.retry(exc=e, countdown=seconds_to_wait)
+
+
+def queue_start_launchpad_demo(
+    demo_url,
+    user,
+    repo,
+    branch,
+    pr,
+    context
+):
+    logger = logging.getLogger(__name__)
+    logger.info(
+        "Adding demo to queue for %s/%s on PR %s (%s)",
+        "launchpad",
+        repo,
+        pr,
+        demo_url,
+    )
+
+    start_launchpad_demo_task.delay(
+        context=context,
+        **context
+    )
+
+
+def queue_stop_launchpad_demo(
+    demo_url,
+    user,
+    repo,
+    branch,
+    pr,
+    context
+):
+    logger = logging.getLogger(__name__)
+    logger.info(
+        "Adding demo removal to queue for %s/%s on PR %s (%s)",
+        "launchpad",
+        repo,
+        pr,
+        demo_url,
+    )
+
+    stop_launchpad_demo_task.delay(
+        context=context,
+        **context
+    )

--- a/bin/data/github.json
+++ b/bin/data/github.json
@@ -1,0 +1,13 @@
+{
+  "action": "opened",
+  "number": 9000,
+  "repository": {
+    "name": "snapcraft.io",
+    "owner": {
+      "login": "canonical-websites",
+    }
+  },
+  "sender": {
+    "login": "jpmartinspt",
+  }
+}

--- a/bin/data/launchpad.json
+++ b/bin/data/launchpad.json
@@ -1,0 +1,11 @@
+{
+  "action": "modified",
+  "merge_proposal": "~canonical-webteam/ledemo/+git/ledemo/+merge/358015",
+  "new": {
+    "source_git_path": "refs/heads/add_readme",
+    "source_git_repository": "/~canonical-webteam/maas/+git/ledemo",
+    "target_git_repository": "/~canonical-webteam/ledemo/+git/ledemo"
+  },
+  "old": {
+  }
+}

--- a/bin/send_fake_github_webhook
+++ b/bin/send_fake_github_webhook
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+FILE="${1}"
+
+curl -X POST \
+    --header "X-GITHUB-EVENT: pull_request" \
+    -d @${FILE} \
+    http://localhost:8099/webhook/github

--- a/bin/send_fake_launchpad_webhook
+++ b/bin/send_fake_launchpad_webhook
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+FILE="${1}"
+
+curl -X POST \
+    --header "X-LAUNCHPAD-EVENT-TYPE: merge-proposal:0.1" \
+    -d @${FILE} \
+    http://localhost:8099/webhook/launchpad


### PR DESCRIPTION
## Done

Added the necessary logic to trigger demos on launchpad merge proposals and also to stop them when the proposals are closed.

## QA

- Run `docker-compose up -d`
- Run `docker-compose logs -f demoservice-worker`
- On a new terminal run `./bin/send_fake_launchpad_webhook bin/data/launchpad.json`
- Check the worker logs to see if the demos is being created.
- When you see a success message in the logs, run `docker ps` on your host and verify you have a ledemo project running and accessible on the mapped port.
- Change the `bin/data/launchpad.json` `action` key to `closed`.
- Run `./bin/send_fake_launchpad_webhook bin/data/launchpad.json`
- Check the logs and once you get a message saying the demo has been removed run `docker ps -a` and verify the container is gone. Run `docker images -a` and verify images have also been cleared

## Issues

Fixes https://github.com/ubuntudesign/base-squad/issues/220
Fixes https://github.com/ubuntudesign/base-squad/issues/231