### PR TITLE
Update demo_index template to support launchpad demos

### DIFF
--- a/app/demoservice/templates/demo_index.html
+++ b/app/demoservice/templates/demo_index.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block content %}
-  <div class="strip">
+  <div class="p-strip">
     <div class="row">
       <div class="col-12">
         <h1>Running demos</h1>
@@ -10,11 +10,11 @@
     <div class="row">
       <div class="col-12">
         {% if demos %}
-        <table class="p-table" role="grid">
+          <table class="p-table" role="grid">
             <thead>
               <tr role="row">
                 <th scope="col" role="columnheader" id="t-url" aria-sort="none">Name</th>
-                <th scope="col" role="columnheader" id="t-github" aria-sort="none">GitHub</th>
+                <th scope="col" role="columnheader" id="t-github" aria-sort="none">VCS</th>
                 <th scope="col" role="columnheader" id="t-github" aria-sort="none">Options</th>
               </tr>
             </thead>
@@ -26,12 +26,14 @@
                       <a href="{{ demo.url_full }}">{{ demo.url }}</a>
                     </td>
                     <td role="gridcell">
-                      <a href="{{ demo.github_url }}" class="p-link--external">GitHub</a>
+                      <a href="{{ demo.github_url }}" class="p-link--external">{{ demo.vcs_provider }}</a>
                     </td>
                     <td role="gridcell">
-                      <a href="{% url 'demo_start'%}?url={{ demo.github_url }}">Update</a>
-                      <span> | </span>
-                      <a href="{% url 'demo_stop' %}?url={{ demo.github_url }}">Stop</a>
+                      {% if demo.vcs_provider != "launchpad" %}
+                        <a href="{% url 'demo_start'%}?url={{ demo.github_url }}">Update</a>
+                        <span> | </span>
+                        <a href="{% url 'demo_stop' %}?url={{ demo.github_url }}">Stop</a>
+                      {% endif %}
                     </td>
                   </tr>
                 {% endfor %}
@@ -39,7 +41,7 @@
             </tbody>
           </table>
         {% else %}
-          No currently running demos found.
+          No running demos found.
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
## Done

Updated the demo index template to better support the listing if launchpad projects. This was done by adding links to launchpad merge proposals for running launchpad demos and also by removing options that are not supported for launchpad demos.

## QA
- Run `docker-compose up -d`.
- Run `docker run --rm --detach -l run.demo.url=demo-pr-1.run.demo.haus -l run.demo.url_full=http://demo-pr-1.run.demo.haus/ -l run.demo.github_pr=1 -l run.demo.github_user=canonical-websites -l run.demo.github_repo=demo -l run.demo=True -l run.demo.fake=True -l run.demo.vcs_provider=github nginx:latest`
- Run `docker run --rm --detach -l run.demo.url=demo1-pr-1.run.demo.haus -l run.demo.url_full=http://demo1-pr-1.run.demo.haus/ -l run.demo.github_pr=1 -l run.demo.github_user=canonical-websites -l run.demo.github_repo=demo1 -l run.demo=True -l run.demo.fake=True -l run.demo.vcs_provider=launchpad nginx:latest`
- Access localhost:8099 and verify that demo links to github and demo1 links to launchpad.
- Demo1 should also not have Start and Stop options as we don't support that trough the interface yet.

## Issues

Fixes #53 