### PR TITLE
Add team membership validation to start launchpad demos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . /app
 RUN apk update \
     # apk upgrade && \
     && apk add --no-cache bash git openssh postgresql python3 \
-    && apk add --no-cache --virtual build-dependencies build-base gcc make musl-dev postgresql-dev python3-dev \
+    && apk add --no-cache --virtual build-dependencies build-base gcc libffi-dev make musl-dev postgresql-dev python3-dev \
     && echo "### INSTALL PYTHON3/PIP3" \
     && python3 -m ensurepip \
     && rm -r /usr/lib/python*/ensurepip \

--- a/app/demoservice/settings.py
+++ b/app/demoservice/settings.py
@@ -70,7 +70,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'demoservice.wsgi.application'
 
-
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
@@ -98,7 +97,6 @@ if POSTGRES_HOST:
         }
     }
 
-
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 
@@ -117,7 +115,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 
@@ -131,12 +128,10 @@ USE_L10N = True
 
 USE_TZ = True
 
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
-
 
 AUTHENTICATION_BACKENDS = (
     'django_openid_auth.auth.OpenIDBackend',
@@ -173,6 +168,8 @@ if DEBUG:
     DEMO_DIR = os.path.join(BASE_DIR, 'demos')
 
 GITHUB_WEBHOOK_SECRET = os.environ.get('GITHUB_WEBHOOK_SECRET')
+
+LAUNCHPAD_ALLOWED_TEAMS = ["canonical-webmonkeys"]
 LAUNCHPAD_WEBHOOK_SECRET = os.environ.get('LAUNCHPAD_WEBHOOK_SECRET')
 
 DOCKERFILE_REPO_TEMPLATE = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ github3.py==0.9.6
 gunicorn==19.7.1
 idna==2.5
 kombu==4.0.2
+launchpadlib==1.10.6
 psycopg2==2.7.1
 python-logstash==0.4.6
 python3-openid==3.1.0


### PR DESCRIPTION
## Done

Added team membership validation to start launchpad demos. Whenever a user tries to start a launchpad demo the app will check if he is a member of any of the teams specified in settings.LAUNCHPAD_ALLOWED_TEAMS.

## QA
- Run `docker-compose up -d`.
- Edit `bin/data/launchpad.json` to be `{
  "action": "modified",
  "merge_proposal": "~canonical-webteam/ledemo/+git/ledemo/+merge/358015",
  "new": {
    "source_git_path": "refs/heads/add_readme",
    "source_git_repository": "/~imnomonkey/ledemo/+git/ledemo",
    "target_git_repository": "/~canonical-webteam/ledemo/+git/ledemo"
  },
  "old": {
  }
}
`
- Run `curl -X POST --header "X-LAUNCHPAD-EVENT-TYPE: merge-proposal:0.1" http://localhost:8099/webhook/launchpad -d @bin/data/launchpad.json`
- Run `docker-compose logs demoservice-worker` and see you have a message saying the user is not part of the canonical-webmonkeys team.

## Issues

Fixes #55 