### PR TITLE
Make PR state check button triggered

### DIFF
--- a/app/demoservice/templates/demo_index.html
+++ b/app/demoservice/templates/demo_index.html
@@ -10,6 +10,7 @@
     <div class="row">
       <div class="col-12">
         {% if demos %}
+          <button class="p-button--positive" onclick="checkPrStates();">Check PR States</button>
           <table class="p-table" role="grid">
             <thead>
               <tr role="row">
@@ -33,7 +34,7 @@
                       <span
                         class="js-pr-state"
                         data-url="https://api.github.com/repos/{{demo.github_user}}/{{demo.github_repo}}/pulls/{{demo.github_pr}}"
-                      ></span>
+                      >Not checked</span>
                     </td>
                     <td role="gridcell">
                       {% if demo.vcs_provider != "launchpad" %}
@@ -54,16 +55,18 @@
     </div>
   </div>
   <script>
-    var states = document.querySelectorAll('.js-pr-state');
-    states.forEach(function (state) {
-      var url = state.dataset.url;
-      fetch(url)
-        .then(function(response) {
-          return response.json();
-        })
-        .then(function(json) {
-          state.innerHTML = json ? json.state : "Could not fetch";
-        });
-    });
+    function checkPrStates() {
+      var states = document.querySelectorAll('.js-pr-state');
+      states.forEach(function (state) {
+        var url = state.dataset.url;
+        fetch(url)
+          .then(function(response) {
+            return response.json();
+          })
+          .then(function(json) {
+            state.innerHTML = json ? json.state : "Could not fetch";
+          });
+      });
+    }
   </script>
 {% endblock %}


### PR DESCRIPTION
## Done
Instead of checking for PR states on page load, we now have a button that can be pressed whenever we need to do so. This will help us stay within the GitHub API's request rate limits.

## QA
- `./bin/create_fake_demo snapcraft.io {real_pr_number}`
- `docker-compose up -d`
- go to '`ocalhost:8099`
- Press the "Check PR state" button and check it pulls the right status.